### PR TITLE
Handle Notion pagination for large databases

### DIFF
--- a/server.js
+++ b/server.js
@@ -53,8 +53,17 @@ app.post("/api/notion-merge/databases/retrieve", async (req, res) => {
 
 app.post("/api/notion-merge/databases/query", async (req, res) => {
   const token = getToken(req);
-  const { database_id } = req.body;
-  await notionRequest(res, `/databases/${database_id}/query`, "POST", undefined, token);
+  const { database_id, start_cursor, page_size } = req.body;
+  const body = {};
+  if (start_cursor) body.start_cursor = start_cursor;
+  if (page_size) body.page_size = page_size;
+  await notionRequest(
+    res,
+    `/databases/${database_id}/query`,
+    "POST",
+    Object.keys(body).length ? body : undefined,
+    token
+  );
 });
 
 app.patch("/api/notion-merge/databases/update", async (req, res) => {


### PR DESCRIPTION
## Summary
- allow proxy endpoint to include start_cursor/page_size when querying databases
- fetch and update all database pages by iterating over Notion pagination
- refresh page list after updates using paginated queries

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db7910cd4832fb84fa38704b057c9